### PR TITLE
maybe minor typo?

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -41,7 +41,7 @@ Otherwise you can download the repository in [this zip file](https://github.com/
 
 To start Jupyter, run:
 
-    cd CompStats/code
+    cd CompStats
     jupyter notebook
 
 Jupyter should launch your default browser or open a tab in an existing browser window.


### PR DESCRIPTION
There is no code directory (perhaps there used to be?), so (I think) students only need to `cd CompStats`. They don't need to `cd CompStats/code`.